### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -32,6 +32,12 @@ class FrankEnergieQuery:
             "variables": self.variables,
         }
 
+def sanitize_query(query: FrankEnergieQuery) -> dict[str, Any]:
+    sanitized_query = query.to_dict()
+    if "password" in sanitized_query["variables"]:
+        sanitized_query["variables"]["password"] = "****"
+    return sanitized_query
+
 class FrankEnergie:
     """FrankEnergie API."""
 
@@ -74,8 +80,8 @@ class FrankEnergie:
                 "Authorization": f"Bearer {self._auth.authToken}"
             } if self._auth is not None else None
             print(f"Request headers: {headers}")
-            # print(f"Request payload: {query}")
-            print(f"Request payload: {query.to_dict()}")
+            sanitized_query = sanitize_query(query)
+            print(f"Request payload: {sanitized_query}")
 
             async with self._session.post(
                 self.DATA_URL,


### PR DESCRIPTION
Fixes [https://github.com/HiDiHo01/python-frank-energie/security/code-scanning/1](https://github.com/HiDiHo01/python-frank-energie/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged. The best way to achieve this is to sanitize the data before logging it. Specifically, we should remove or mask sensitive information from the `query` object before converting it to a dictionary and logging it.

1. Modify the `_query` method to sanitize the `query` object before logging.
2. Create a helper function to remove or mask sensitive information from the `variables` dictionary.
3. Update the logging statements to use the sanitized version of the `query` object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
