### PR TITLE
Fix code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -79,9 +79,9 @@ class FrankEnergie:
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {self._auth.authToken}"
             } if self._auth is not None else None
-            print(f"Request headers: {headers}")
             sanitized_query = sanitize_query(query)
-            print(f"Request payload: {sanitized_query}")
+            # print(f"Request headers: {headers}")
+            # print(f"Request payload: {sanitized_query}")
 
             async with self._session.post(
                 self.DATA_URL,
@@ -96,7 +96,7 @@ class FrankEnergie:
 
             # print(f"Response status code: {resp.status}")
             # print(f"Response headers: {resp.headers}")
-            print(f"Response body: {response}")
+            # print(f"Response body: {response}")
 
             if resp.status == 200:
                 return response


### PR DESCRIPTION
Fixes [https://github.com/HiDiHo01/python-frank-energie/security/code-scanning/2](https://github.com/HiDiHo01/python-frank-energie/security/code-scanning/2)

To fix the problem, we should ensure that no sensitive information is logged. This can be achieved by removing or commenting out the logging statements that print the request headers and payload. Additionally, we should ensure that the `sanitize_query` function comprehensively masks any sensitive data.

- Remove or comment out the logging statements that print the request headers and payload.
- Ensure that the `sanitize_query` function masks all sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
